### PR TITLE
Fix two race conditions in RecyclerBinder.

### DIFF
--- a/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.java
+++ b/litho-core/src/main/java/com/facebook/litho/config/ComponentsConfiguration.java
@@ -286,6 +286,12 @@ public class ComponentsConfiguration {
 
   public static boolean enableMountableInFacecast = false;
 
+  /**
+   * Attempts to compute the working range when a collection or its items are not yet laid out will
+   * save the desired working range, and apply it once layout completes.
+   */
+  public static boolean useReliableWorkingRange = false;
+
   private static boolean sReduceMemorySpikeUserSession = false;
   private static boolean sReduceMemorySpikeDataDiffSection = false;
   private static boolean sReduceMemorySpikeGetUri = false;

--- a/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
+++ b/litho-widget/src/main/java/com/facebook/litho/widget/RecyclerBinder.java
@@ -52,6 +52,8 @@ import com.facebook.litho.ComponentContext;
 import com.facebook.litho.ComponentLogParams;
 import com.facebook.litho.ComponentTree;
 import com.facebook.litho.ComponentTree.MeasureListener;
+import com.facebook.litho.ComponentTree.WorkingRangeAndPositionHolder;
+import com.facebook.litho.ComponentTree.WorkingRangeHolder;
 import com.facebook.litho.ComponentUtils;
 import com.facebook.litho.ComponentsLogger;
 import com.facebook.litho.ComponentsReporter;
@@ -220,6 +222,8 @@ public class RecyclerBinder
   private @Nullable ComponentWarmer mComponentWarmer;
   private final RunnableHandler mPreallocateMountContentHandler;
   private final boolean mPreallocatePerMountSpec;
+
+  private @Nullable WorkingRangeHolder mPendingWorkingRange;
 
   private MeasureListener getMeasureListener(final ComponentTreeHolder holder) {
     return new MeasureListener() {
@@ -1184,7 +1188,8 @@ public class RecyclerBinder
   public void setSubAdapterModeRecyclerView(RecyclerView recyclerView) {
     if (!mIsSubAdapter) {
       throw new IllegalStateException(
-          "Cannot set a subadapter RecyclerView on a RecyclerBinder which is not in subadapter mode.");
+          "Cannot set a subadapter RecyclerView on a RecyclerBinder which is not in subadapter"
+              + " mode.");
     }
 
     registerDrawListener(recyclerView);
@@ -1195,7 +1200,8 @@ public class RecyclerBinder
   public void removeSubAdapterModeRecyclerView(RecyclerView recyclerView) {
     if (!mIsSubAdapter) {
       throw new IllegalStateException(
-          "Cannot remove a subadapter RecyclerView on a RecyclerBinder which is not in subadapter mode.");
+          "Cannot remove a subadapter RecyclerView on a RecyclerBinder which is not in subadapter"
+              + " mode.");
     }
 
     unregisterDrawListener(recyclerView);
@@ -2335,7 +2341,8 @@ public class RecyclerBinder
         shouldMeasureItemForSize(widthSpec, heightSpec, scrollDirection, canRemeasure);
     if (mHasManualEstimatedViewportCount && shouldMeasureItemForSize) {
       throw new RuntimeException(
-          "Cannot use manual estimated viewport count when the RecyclerBinder needs an item to determine its size!");
+          "Cannot use manual estimated viewport count when the RecyclerBinder needs an item to"
+              + " determine its size!");
     }
 
     mIsInMeasure.set(true);
@@ -3330,26 +3337,36 @@ public class RecyclerBinder
       int lastVisibleIndex,
       int firstFullyVisibleIndex,
       int lastFullyVisibleIndex) {
+    onNewWorkingRange(
+        new WorkingRangeHolder(
+            firstVisibleIndex, lastVisibleIndex, firstFullyVisibleIndex, lastFullyVisibleIndex));
+  }
+
+  private void onNewWorkingRange(WorkingRangeHolder workingRange) {
     if (mEstimatedViewportCount == UNSET
-        || firstVisibleIndex == RecyclerView.NO_POSITION
-        || lastVisibleIndex == RecyclerView.NO_POSITION) {
+        || workingRange.firstVisibleIndex == RecyclerView.NO_POSITION
+        || workingRange.lastVisibleIndex == RecyclerView.NO_POSITION) {
+      if (ComponentsConfiguration.useReliableWorkingRange) {
+        mPendingWorkingRange = workingRange;
+      }
       return;
     }
 
-    final int rangeSize = Math.max(mEstimatedViewportCount, lastVisibleIndex - firstVisibleIndex);
+    final int rangeSize =
+        Math.max(
+            mEstimatedViewportCount,
+            workingRange.lastVisibleIndex - workingRange.firstVisibleIndex);
     final int layoutRangeSize = (int) (rangeSize * mRangeRatio);
-    final int rangeStart = Math.max(0, firstVisibleIndex - layoutRangeSize);
+    final int rangeStart = Math.max(0, workingRange.firstVisibleIndex - layoutRangeSize);
     final int rangeEnd =
-        Math.min(firstVisibleIndex + rangeSize + layoutRangeSize, mComponentTreeHolders.size() - 1);
+        Math.min(
+            workingRange.firstVisibleIndex + rangeSize + layoutRangeSize,
+            mComponentTreeHolders.size() - 1);
 
     for (int position = rangeStart; position <= rangeEnd; position++) {
       final ComponentTreeHolder holder = mComponentTreeHolders.get(position);
       holder.checkWorkingRangeAndDispatch(
-          position,
-          firstVisibleIndex,
-          lastVisibleIndex,
-          firstFullyVisibleIndex,
-          lastFullyVisibleIndex);
+          new WorkingRangeAndPositionHolder(position, workingRange));
     }
   }
 
@@ -3373,7 +3390,15 @@ public class RecyclerBinder
     final boolean didRangeExtremitiesChange;
 
     synchronized (this) {
-      if (!isMeasured() || mEstimatedViewportCount == UNSET) {
+      // When mHasDynamicItemHeight is set, isMeasured() always returns false, to trigger re-measure
+      // of the RecyclerView whenever a new child item is measured. However, this causes this
+      // function to return early, preventing layout ranges from being applied.
+      boolean isMeasured =
+          ComponentsConfiguration.useReliableWorkingRange && mHasDynamicItemHeight
+              ? mIsMeasured.get()
+              : isMeasured();
+
+      if (!isMeasured || mEstimatedViewportCount == UNSET) {
         return;
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you taking the time to work on these 
changes. Please provide enough information so that others can review your pull request. The three 
fields below are mandatory. -->

## Summary

If the collection has not completed initial layout by the time onNewWorkingRange() is called, it will short circuit and not be called again.

If a collection item has not completed initial layout by the time we attempt to check if it belongs to a working range, the call noop-s and is not attempted again.

In each case, save the working range and apply it when the layout completes.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be
a brief one line we can mention in our release notes: https://github.com/facebook/litho/releases -->

Fix two race conditions in RecyclerBinder.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, output of 
the test runner and how you invoked it (you've added tests, right?), screenshots/videos if the pull 
request changes UI. -->
